### PR TITLE
Fixed issue with custom simple_form date input

### DIFF
--- a/app/inputs/currency_input.rb
+++ b/app/inputs/currency_input.rb
@@ -1,6 +1,6 @@
 class CurrencyInput < SimpleForm::Inputs::Base
   
-  def input
+  def input(wrapper_options = nil)
     options[:hint] = 'Numbers only, e.g., 50000' unless options.has_key?(:hint)
     input_html_options[:class] << 'money'
     

--- a/app/inputs/date_base_input.rb
+++ b/app/inputs/date_base_input.rb
@@ -1,22 +1,17 @@
 class DateBaseInput < SimpleForm::Inputs::Base
-  def input
+
+  def input(wrapper_options = nil)
     options[:hint] = hint_text unless options.has_key?(:hint)
     input_html_options[:class] << date_picker_class
     input_html_options[:class] << options[:class]
     input_html_options[:class] << "form-control"
 
     input_html_options[:data] ||= {} 
-    input_html_options[:data]["date-format"] ||= date_format if date_format.present?
-    input_html_options[:value] = object.send(attribute_name)
 
-    value = object.send(attribute_name)
-    if value.present? 
-      value = strftime_format.present? ? value.strftime(strftime_format) : value.to_formatted_s
-      input_html_options[:value] = value
-    end
+    # Set the date format for JS helper. Don't set the value, though - assume that the user will provide a value in the same format
+    input_html_options[:data]["date-format"] ||= date_format if date_format.present?
         
     template.content_tag(:div, class: 'date') do
-      # template.concat @builder.label(attribute_name, class: 'control-label')
       template.content_tag(:div, class: 'input-group date') do 
         template.concat @builder.text_field(attribute_name, input_html_options)
         template.concat template.content_tag(:span, template.content_tag(:i, "", class: "glyphicon glyphicon-th"), class: 'input-group-addon')

--- a/app/inputs/e_mail_input.rb
+++ b/app/inputs/e_mail_input.rb
@@ -1,7 +1,7 @@
 # Wanted to have class of EmailInput, but couldn't get simple_form to recognize.
 class EMailInput < SimpleForm::Inputs::Base
 
-  def input(wrapper_options = nil))
+  def input(wrapper_options = nil)
     template.content_tag(:div, class: 'input-prepend') do
       template.safe_join([
         template.content_tag(:span, template.icon_email, class: 'add-on') ,

--- a/app/inputs/e_mail_input.rb
+++ b/app/inputs/e_mail_input.rb
@@ -1,7 +1,7 @@
 # Wanted to have class of EmailInput, but couldn't get simple_form to recognize.
 class EMailInput < SimpleForm::Inputs::Base
 
-  def input
+  def input(wrapper_options = nil))
     template.content_tag(:div, class: 'input-prepend') do
       template.safe_join([
         template.content_tag(:span, template.icon_email, class: 'add-on') ,

--- a/lib/ucb_rails/version.rb
+++ b/lib/ucb_rails/version.rb
@@ -1,3 +1,3 @@
 module UcbRails
-  VERSION = "0.0.17.1"
+  VERSION = "0.0.17.2"
 end


### PR DESCRIPTION
Use the natural simple_form process for setting initial value to avoid making assumptions about the data type. Aligned method signature with latest simple_form spec. Bumped version.

Simple_form avoids modifying the values in components. Doing the same saves us from a world of hurt. This puts the responsibility to correctly format the input data onto the developer. This change does not affect how the component is used.